### PR TITLE
CQI-14: Disable demo data loading for integration tests

### DIFF
--- a/src/integration-test/java/org/openlmis/cce/AuditLogInitializerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/cce/AuditLogInitializerIntegrationTest.java
@@ -56,7 +56,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@ActiveProfiles({"test", "init-audit-log"})
+@ActiveProfiles({"test", "init-audit-log", "test-run"})
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class AuditLogInitializerIntegrationTest {

--- a/src/integration-test/java/org/openlmis/cce/repository/BaseCrudRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/cce/repository/BaseCrudRepositoryIntegrationTest.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @Transactional
 public abstract class BaseCrudRepositoryIntegrationTest<T extends BaseEntity> {
 

--- a/src/integration-test/java/org/openlmis/cce/web/BaseWebIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/cce/web/BaseWebIntegrationTest.java
@@ -72,7 +72,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootConfiguration
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @TestPropertySource(properties = {"service.url=" + BaseWebIntegrationTest.SERVICE_URL})
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @SuppressWarnings("PMD.TooManyMethods")
 public abstract class BaseWebIntegrationTest {
 

--- a/src/main/java/org/openlmis/cce/TestDataInitializer.java
+++ b/src/main/java/org/openlmis/cce/TestDataInitializer.java
@@ -29,7 +29,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("demo-data")
+@Profile("demo-data & !test-run")
 @Order(5)
 public class TestDataInitializer implements CommandLineRunner {
   private static final XLogger XLOGGER = XLoggerFactory.getXLogger(TestDataInitializer.class);


### PR DESCRIPTION
Demo data was previously being loaded before the tests were run, so they were affected by records fetched from a csv.