### PR TITLE
Add UNKNOWN functional status to BE

### DIFF
--- a/src/main/java/org/openlmis/cce/domain/FunctionalStatus.java
+++ b/src/main/java/org/openlmis/cce/domain/FunctionalStatus.java
@@ -16,6 +16,7 @@
 package org.openlmis.cce.domain;
 
 public enum FunctionalStatus {
+  UNKNOWN,
   FUNCTIONING,
   AWAITING_REPAIR,
   UNSERVICEABLE,


### PR DESCRIPTION
Hi, would it possible to add please this functional status? It's required from one of our clients (an OpenFn client)
I have opened the pair PR on openlmis-cce: https://github.com/OpenLMIS/openlmis-cce-ui/pull/9

## Change

Adds new functional status to allow saving CCE Inventory with UNKNOWN status.

## Build
 
```
$ docker-compose run cce
# gradle clean; gradle build
# exit
$ docker build . --tag openlmis-fork/cce
```
To use it change on the docker-compose.yaml of the openlmis-ref-distro to use the `openlmis-fork/cce` 

## Additional notes
This branch was created from the openlmis-cce `v1.3.3` tag. The version is the one used by the openlmis-ref-distro `v3.17.0`